### PR TITLE
Fixing issues encountered when using carousel in loop mode

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -789,7 +789,7 @@ export default class Carousel extends Component {
         }
 
         if (nextActiveItem === this._itemToSnapTo &&
-            scrollOffset === this._scrollOffsetRef) {
+            (Math.abs(scrollOffset - this._scrollOffsetRef) < 1)) {
             this._repositionScroll(nextActiveItem);
         }
 
@@ -1063,7 +1063,7 @@ export default class Carousel extends Component {
     }
 
     snapToItem (index, animated = true, fireCallback = true) {
-        if (!index || index < 0) {
+        if(index === null || index === undefined || (index < (this.props.loop ? -this.props.loopClonesPerSide : 0))) {
             index = 0;
         }
 


### PR DESCRIPTION
Allow snapping to items at indexes lower than the initial data set when using loopClonesPerSide.
Fix repositions frequently being skipped on android due to fractional scrollOffset values.